### PR TITLE
Set a default encoding when not is supplied.

### DIFF
--- a/src/main/java/cn/bluejoe/elfinder/controller/ConnectorController.java
+++ b/src/main/java/cn/bluejoe/elfinder/controller/ConnectorController.java
@@ -108,7 +108,10 @@ public class ConnectorController
 		// Parse the request
 		ServletFileUpload sfu = new ServletFileUpload();
 		String characterEncoding = request.getCharacterEncoding();
-		sfu.setHeaderEncoding(characterEncoding);
+		if (characterEncoding == null) {
+			characterEncoding = "UTF-8";
+		}
+        sfu.setHeaderEncoding(characterEncoding);
 		FileItemIterator iter = sfu.getItemIterator(request);
 
 		while (iter.hasNext())


### PR DESCRIPTION
If the request doesn’t have an encoding we assume it’s going to be UTF-8.
Fixes #2
