### PR TITLE
Build classes artifact as well as WAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,13 @@
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>9.3.0.v20150612</version>
             </plugin>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <attachClasses>true</attachClasses>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This means that you get a classes artifact as well as a WAR, this makes it much easier to re-use the classes in this project in another maven project by added a dependency of:

```
        <dependency>
            <groupId>org.elfinder</groupId>
            <artifactId>elfinder-servlet-2</artifactId>
            <version>1.0-SNAPSHOT</version>
            <classifier>classes</classifier>
            <type>jar</type>
        </dependency>
```
