### PR TITLE
In the options the path should be the full path.

### DIFF
--- a/src/main/java/cn/bluejoe/elfinder/controller/executor/AbstractCommandExecutor.java
+++ b/src/main/java/cn/bluejoe/elfinder/controller/executor/AbstractCommandExecutor.java
@@ -163,10 +163,10 @@ public abstract class AbstractCommandExecutor implements CommandExecutor
 		return disp;
 	}
 
-	protected Map<String, Object> getOptions(HttpServletRequest request, FsItemEx cwd)
+	protected Map<String, Object> getOptions(HttpServletRequest request, FsItemEx cwd) throws IOException
 	{
 		Map<String, Object> map = new HashMap<String, Object>();
-		map.put("path", cwd.getName());
+		map.put("path", cwd.getPath());
 		map.put("disabled", new String[0]);
 		map.put("separator", "/");
 		map.put("copyOverwrite", 1);


### PR DESCRIPTION
According to https://github.com/Studio-42/elFinder/wiki/Client-Server-API-2.0 the path should be the full path to the current item, rather than the name.
