### PR TITLE
Add support for the size command.

### DIFF
--- a/src/main/java/cn/bluejoe/elfinder/controller/executor/FsItemEx.java
+++ b/src/main/java/cn/bluejoe/elfinder/controller/executor/FsItemEx.java
@@ -104,7 +104,7 @@ public class FsItemEx
 		return _v.getPath(_f);
 	}
 
-	public long getSize()
+	public long getSize() throws IOException
 	{
 		return _v.getSize(_f);
 	}

--- a/src/main/java/cn/bluejoe/elfinder/controller/executors/SizeCommandExecutor.java
+++ b/src/main/java/cn/bluejoe/elfinder/controller/executors/SizeCommandExecutor.java
@@ -1,0 +1,29 @@
+package cn.bluejoe.elfinder.controller.executors;
+
+import cn.bluejoe.elfinder.controller.executor.AbstractJsonCommandExecutor;
+import cn.bluejoe.elfinder.controller.executor.CommandExecutor;
+import cn.bluejoe.elfinder.controller.executor.FsItemEx;
+import cn.bluejoe.elfinder.service.FsService;
+import org.json.JSONObject;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This calculates the total size of all the supplied targets and returns the size in bytes.
+ */
+public class SizeCommandExecutor extends AbstractJsonCommandExecutor implements CommandExecutor
+{
+    @Override
+    protected void execute(FsService fsService, HttpServletRequest request, ServletContext servletContext, JSONObject json) throws Exception
+    {
+        String[] targets = request.getParameterValues("targets[]");
+        long size = 0;
+        for (String target: targets)
+        {
+            FsItemEx item = findItem(fsService, target);
+            size += item.getSize();
+        }
+        json.put("size", size);
+    }
+}

--- a/src/main/java/cn/bluejoe/elfinder/service/FsVolume.java
+++ b/src/main/java/cn/bluejoe/elfinder/service/FsVolume.java
@@ -34,7 +34,7 @@ public interface FsVolume
 
 	FsItem getRoot();
 
-	long getSize(FsItem fsi);
+	long getSize(FsItem fsi) throws IOException;
 
 	String getThumbnailFileName(FsItem fsi);
 


### PR DESCRIPTION
This allows calculation of total file sizes of directories and is used by elFinder when you open the “Get Info” window.
