### PR TITLE
Don’t introduce double slashes in paths.

### DIFF
--- a/src/main/java/cn/bluejoe/elfinder/controller/executor/FsItemEx.java
+++ b/src/main/java/cn/bluejoe/elfinder/controller/executor/FsItemEx.java
@@ -29,7 +29,13 @@ public class FsItemEx
 	{
 		_v = parent._v;
 		_s = parent._s;
-		_f = _v.fromPath(_v.getPath(parent._f) + "/" + name);
+		// Directories may already have a trailing slash on them so we make sure we don't double up
+		String path = _v.getPath(parent._f);
+		if (!path.endsWith("/")) {
+			path = path + "/";
+		}
+		path = path + name;
+		_f = _v.fromPath(path);
 	}
 
 	public FsItemEx createChild(String name) throws IOException


### PR DESCRIPTION
In Sakai our directories always have to have a trailing slash (bad design decision). However if we do this then we start ending up with double slashes in the URLs. Rather than changing this for all Volumes I’ve added a check so that double slashes aren’t introduced.

I'm not 100% sure this is the best solution, but it's the simplest and allows our volumes to work well.
