### PR TITLE
When adding folders to response it shouldn’t be recursive.

### DIFF
--- a/src/main/java/cn/bluejoe/elfinder/controller/executor/AbstractCommandExecutor.java
+++ b/src/main/java/cn/bluejoe/elfinder/controller/executor/AbstractCommandExecutor.java
@@ -35,7 +35,6 @@ public abstract class AbstractCommandExecutor implements CommandExecutor
 			if (f.isFolder())
 			{
 				map.put(f.getHash(), f);
-				addSubfolders(map, f);
 			}
 		}
 	}


### PR DESCRIPTION
This was causing performance problems for us because it was loading all the files in a hierarchy.
It isn’t needed as elfinder will make additional requests to load the additional data.

The commands in which it’s used (open, tree) are only supposed to return one level. And the parents command does the walking back up the tree itself.
