### PR TITLE
In the open command allow a custom URL to be used.

### DIFF
--- a/src/main/java/cn/bluejoe/elfinder/controller/executor/AbstractCommandExecutor.java
+++ b/src/main/java/cn/bluejoe/elfinder/controller/executor/AbstractCommandExecutor.java
@@ -170,6 +170,10 @@ public abstract class AbstractCommandExecutor implements CommandExecutor
 		map.put("separator", "/");
 		map.put("copyOverwrite", 1);
 		map.put("archivers", new Object[0]);
+		String url = cwd.getURL();
+		if (url != null) {
+			map.put("url", url);
+		}
 
 		return map;
 	}

--- a/src/main/java/cn/bluejoe/elfinder/controller/executor/FsItemEx.java
+++ b/src/main/java/cn/bluejoe/elfinder/controller/executor/FsItemEx.java
@@ -180,4 +180,7 @@ public class FsItemEx
 		_v.rename(_f, dst._f);
 	}
 
+	public String getURL() {
+		return _v.getURL(_f);
+	}
 }

--- a/src/main/java/cn/bluejoe/elfinder/localfs/LocalFsVolume.java
+++ b/src/main/java/cn/bluejoe/elfinder/localfs/LocalFsVolume.java
@@ -236,6 +236,13 @@ public class LocalFsVolume implements FsVolume
 		asFile(src).renameTo(asFile(dst));
 	}
 
+	@Override
+	public String getURL(FsItem f)
+	{
+		// We are just happy to not supply a custom URL.
+		return null;
+	}
+
 	public void setName(String name)
 	{
 		_name = name;

--- a/src/main/java/cn/bluejoe/elfinder/service/FsVolume.java
+++ b/src/main/java/cn/bluejoe/elfinder/service/FsVolume.java
@@ -51,4 +51,11 @@ public interface FsVolume
 	OutputStream openOutputStream(FsItem fsi) throws IOException;
 
 	void rename(FsItem src, FsItem dst) throws IOException;
+
+	/**
+	 * Gets the URL for the supplied item.
+	 * @param f The item to get the URL for.
+	 * @return An absolute URL or <code>null</code> if we should not send back a URL.
+	 */
+	String getURL(FsItem f);
 }


### PR DESCRIPTION
In the open command you can supply a URL through which the selected file should be accessed. This is made optional by only adding it if the value is anything other than null.

We need this for Sakai so that we can have people use elfinder to pick a file and then we embed this file in some HTML, but we don’t want the file to be served up all the time through the elfinder connector.
