### PR TITLE
paste command should return just the hashes of removed

### DIFF
--- a/src/main/java/cn/bluejoe/elfinder/controller/executors/PasteCommandExecutor.java
+++ b/src/main/java/cn/bluejoe/elfinder/controller/executors/PasteCommandExecutor.java
@@ -24,8 +24,8 @@ public class PasteCommandExecutor extends AbstractJsonCommandExecutor implements
 		String dst = request.getParameter("dst");
 		boolean cut = "1".equals(request.getParameter("cut"));
 
-		List<FsItemEx> added = new ArrayList<FsItemEx>();
-		List<FsItemEx> removed = new ArrayList<FsItemEx>();
+		List<FsItemEx> added = new ArrayList<>();
+		List<String> removed = new ArrayList<>();
 
 		FsItemEx fsrc = super.findItem(fsService, src);
 		FsItemEx fdst = super.findItem(fsService, dst);
@@ -41,11 +41,11 @@ public class PasteCommandExecutor extends AbstractJsonCommandExecutor implements
 			if (cut)
 			{
 				ftgt.delete();
-				removed.add(ftgt);
+				removed.add(target);
 			}
 		}
 
 		json.put("added", files2JsonArray(request, added));
-		json.put("removed", files2JsonArray(request, removed));
+		json.put("removed", removed);
 	}
 }


### PR DESCRIPTION
The paste command should just return the hashes of the removed files rather than full details. This was causing an error when dragging a file between folders and the file wouldn’t be removed from the interface. The error was:

```
Error: Syntax error, unrecognized expression: #[object ]
```
