### PR TITLE
Prevent runaway thread on bad FsService implmenetaion.

### DIFF
--- a/src/main/java/cn/bluejoe/elfinder/controller/executors/ParentsCommandExecutor.java
+++ b/src/main/java/cn/bluejoe/elfinder/controller/executors/ParentsCommandExecutor.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
+import cn.bluejoe.elfinder.controller.ErrorException;
 import org.json.JSONObject;
 
 import cn.bluejoe.elfinder.controller.executor.AbstractJsonCommandExecutor;
@@ -15,6 +16,10 @@ import cn.bluejoe.elfinder.service.FsService;
 
 public class ParentsCommandExecutor extends AbstractJsonCommandExecutor implements CommandExecutor
 {
+	// This is a limit on the number of parents so that a badly implemented FsService can't
+	// result in a runaway thread.
+	final static int LIMIT = 1024;
+
 	@Override
 	public void execute(FsService fsService, HttpServletRequest request, ServletContext servletContext, JSONObject json)
 			throws Exception
@@ -23,10 +28,14 @@ public class ParentsCommandExecutor extends AbstractJsonCommandExecutor implemen
 
 		Map<String, FsItemEx> files = new HashMap<String, FsItemEx>();
 		FsItemEx fsi = findItem(fsService, target);
-		while (!fsi.isRoot())
+		for (int i = 0; !fsi.isRoot(); i++)
 		{
 			super.addSubfolders(files, fsi);
 			fsi = fsi.getParent();
+			if (i > LIMIT)
+			{
+				throw new ErrorException("Reached recursion limit on parents of: "+ LIMIT);
+			}
 		}
 
 		json.put("tree", files2JsonArray(request, files.values()));


### PR DESCRIPTION
We have a custom implementation of FsService and under some circumstances the call to getParent() would continue to return items that never made it back to a root node. This resulted in a runaway thread. We have fixed this issue within our implementation of FsService, but having a safety net to prevent a runaway  thread is good option.
